### PR TITLE
feat: Custom domain to load analytics tracking script

### DIFF
--- a/gridsome.config.js
+++ b/gridsome.config.js
@@ -43,7 +43,8 @@ module.exports = {
       use: 'gridsome-plugin-plausible-analytics',
       options: {
         dataDomain: 'michaelpellegrini.com',
-      }
+        customDomain: 'stats.michaelpellegrini.com',
+      },
     },
   ],
   css: {


### PR DESCRIPTION
Serve the tracking script from our domain name as a
first-party resource instead of loading the script
from plausible's domain.